### PR TITLE
Use ambient light baseline for rewards

### DIFF
--- a/sketch_aug14b.ino
+++ b/sketch_aug14b.ino
@@ -445,10 +445,10 @@ int16_t compute_reward_q8(){ // returns Q8 fixed in [-256..256]
 
   }
 
-  // Normalize overall brightness to [-10,10]
-  int brightness = (r + l + c) / 3; // average brightness 0..1023
-  int16_t bright_norm = (int16_t)((int32_t)brightness * 20 / 1023) - 10; // [-10..10]
-  int16_t r_q8 = (int16_t)bright_norm * 256 / 10; // scale to Q8
+  // Raw reward: brightness relative to ambient light (A3)
+  int side_avg = (r + l) / 2;             // average of side sensors
+  int diff = side_avg - c;                // relative to ambient
+  int16_t r_q8 = (int16_t)((int32_t)diff * 256 / 1023); // scale to Q8
 
   // Penalize staying still
   if (MOTOR9_DIRS[last_motor_bin][0] == 0 && MOTOR9_DIRS[last_motor_bin][1] == 0) {

--- a/sketch_aug16a.ino
+++ b/sketch_aug16a.ino
@@ -156,7 +156,9 @@ BinaryNN net;
 uint8_t prob[BinaryNN::MAX_WEIGHTS_BITS];
 uint8_t cur_bits[(BinaryNN::MAX_WEIGHTS_BITS+7)/8];
 uint8_t prev_bits[(BinaryNN::MAX_WEIGHTS_BITS+7)/8];
-int16_t prev_reward = 0;
+// Running average reward baseline
+int16_t reward_avg_q8 = 0;
+const uint8_t RAVG_BETA = 4;
 bool have_prev = false;
 
 // -----------------------------
@@ -284,9 +286,10 @@ int16_t compute_reward_q8(){
   if (last_plate_contact) return PLATE_PENALTY_Q8;
   if (last_button_pressed) return BUTTON_REWARD_Q8;
 
-  int brightness = (r + l + c) / 3;
-  int16_t bright_norm = (int16_t)((int32_t)brightness * 20 / 1023) - 10;
-  int16_t r_q8 = (int16_t)bright_norm * 256 / 10;
+  // Reward relative to ambient light (A3)
+  int side_avg = (r + l) / 2;
+  int diff = side_avg - c;
+  int16_t r_q8 = (int16_t)((int32_t)diff * 256 / 1023);
 
   if (MOTOR9_DIRS[last_motor_bin][0] == 0 && MOTOR9_DIRS[last_motor_bin][1] == 0) {
     r_q8 += MOTOR_IDLE_PENALTY_Q8;
@@ -354,14 +357,15 @@ void loop(){
   last_beep_bin  = b_bin;
 
   int16_t r_q8 = compute_reward_q8();
+  int16_t adv_q8 = r_q8 - reward_avg_q8;
+  reward_avg_q8 += (adv_q8 >> RAVG_BETA);
 
   if (have_prev){
-    if (r_q8 >= prev_reward) cga_update(cur_bits, prev_bits, nW);
+    if (adv_q8 >= 0) cga_update(cur_bits, prev_bits, nW);
     else cga_update(prev_bits, cur_bits, nW);
   }
   uint16_t nB = (nW + 7) >> 3;
   memcpy(prev_bits, cur_bits, nB);
-  prev_reward = r_q8;
   have_prev = true;
 
   Serial.print("r_q8="); Serial.println(r_q8);

--- a/sketch_cga_bnn.ino
+++ b/sketch_cga_bnn.ino
@@ -187,7 +187,9 @@ BinaryRNN net;
 uint8_t prob[BinaryRNN::MAX_WEIGHTS_BITS];
 uint8_t cur_bits[(BinaryRNN::MAX_WEIGHTS_BITS+7)/8];
 uint8_t prev_bits[(BinaryRNN::MAX_WEIGHTS_BITS+7)/8];
-int16_t prev_reward = 0;
+// Running average of rewards for baseline
+int16_t reward_avg_q8 = 0;
+const uint8_t RAVG_BETA = 4; // EMA: new += (r - avg)/16
 bool have_prev = false;
 
 // -----------------------------
@@ -315,9 +317,10 @@ int16_t compute_reward_q8(){
   if (last_plate_contact) return PLATE_PENALTY_Q8;
   if (last_button_pressed) return BUTTON_REWARD_Q8;
 
-  int brightness = (r + l + c) / 3;
-  int16_t bright_norm = (int16_t)((int32_t)brightness * 20 / 1023) - 10;
-  int16_t r_q8 = (int16_t)bright_norm * 256 / 10;
+  // Reward relative to ambient light on A3
+  int side_avg = (r + l) / 2;
+  int diff = side_avg - c;
+  int16_t r_q8 = (int16_t)((int32_t)diff * 256 / 1023);
 
   if (MOTOR9_DIRS[last_motor_bin][0] == 0 && MOTOR9_DIRS[last_motor_bin][1] == 0) {
     r_q8 += MOTOR_IDLE_PENALTY_Q8;
@@ -385,14 +388,15 @@ void loop(){
   last_beep_bin  = b_bin;
 
   int16_t r_q8 = compute_reward_q8();
+  int16_t adv_q8 = r_q8 - reward_avg_q8;
+  reward_avg_q8 += (adv_q8 >> RAVG_BETA);
 
   if (have_prev){
-    if (r_q8 >= prev_reward) cga_update(cur_bits, prev_bits, nW);
+    if (adv_q8 >= 0) cga_update(cur_bits, prev_bits, nW);
     else cga_update(prev_bits, cur_bits, nW);
   }
   uint16_t nB = (nW + 7) >> 3;
   memcpy(prev_bits, cur_bits, nB);
-  prev_reward = r_q8;
   have_prev = true;
 
   Serial.print("r_q8="); Serial.println(r_q8);

--- a/sketch_cga_tnn.ino
+++ b/sketch_cga_tnn.ino
@@ -159,7 +159,9 @@ uint8_t prob_neg[TernaryNN::MAX_WEIGHTS]; // P(weight=-1)
 uint8_t prob_pos[TernaryNN::MAX_WEIGHTS]; // P(weight=+1)
 int8_t cur_trits[TernaryNN::MAX_WEIGHTS];
 int8_t prev_trits[TernaryNN::MAX_WEIGHTS];
-int16_t prev_reward = 0;
+// Running reward baseline
+int16_t reward_avg_q8 = 0;
+const uint8_t RAVG_BETA = 4;
 bool have_prev = false;
 
 // -----------------------------
@@ -289,9 +291,10 @@ int16_t compute_reward_q8(){
   if (last_plate_contact) return PLATE_PENALTY_Q8;
   if (last_button_pressed) return BUTTON_REWARD_Q8;
 
-  int brightness = (r + l + c) / 3;
-  int16_t bright_norm = (int16_t)((int32_t)brightness * 20 / 1023) - 10;
-  int16_t r_q8 = (int16_t)bright_norm * 256 / 10;
+  // Reward relative to ambient light
+  int side_avg = (r + l) / 2;
+  int diff = side_avg - c;
+  int16_t r_q8 = (int16_t)((int32_t)diff * 256 / 1023);
 
   if (MOTOR9_DIRS[last_motor_bin][0] == 0 && MOTOR9_DIRS[last_motor_bin][1] == 0) {
     r_q8 += MOTOR_IDLE_PENALTY_Q8;
@@ -358,13 +361,14 @@ void loop(){
   last_beep_bin  = b_bin;
 
   int16_t r_q8 = compute_reward_q8();
+  int16_t adv_q8 = r_q8 - reward_avg_q8;
+  reward_avg_q8 += (adv_q8 >> RAVG_BETA);
 
   if (have_prev){
-    if (r_q8 >= prev_reward) cga_update_trits(cur_trits, prev_trits, nW);
+    if (adv_q8 >= 0) cga_update_trits(cur_trits, prev_trits, nW);
     else cga_update_trits(prev_trits, cur_trits, nW);
   }
   memcpy(prev_trits, cur_trits, nW);
-  prev_reward = r_q8;
   have_prev = true;
 
   Serial.print("r_q8="); Serial.println(r_q8);


### PR DESCRIPTION
## Summary
- Compute raw reward from side LDR readings relative to ambient light on pin A3.
- Track exponential moving average of rewards and apply updates based on advantage.

## Testing
- `arduino-cli compile sketch_aug14b.ino` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a144ba1f30832981ca4a89b716e20f