### PR TITLE
Reward total LDR brightness in Aug16 sketch

### DIFF
--- a/sketch_aug16a.ino
+++ b/sketch_aug16a.ino
@@ -452,10 +452,9 @@ int16_t compute_reward_q8(){
   if (last_plate_contact) return PLATE_PENALTY_Q8;
   if (last_button_pressed) return BUTTON_REWARD_Q8;
 
-  // Reward relative to ambient light (A3)
-  int side_avg = (r + l) / 2;
-  int diff = side_avg - c;
-  int16_t r_q8 = (int16_t)((int32_t)diff * 256 / 1023);
+  // Reward based on total brightness across all LDR sensors
+  int total = r + l + c;
+  int16_t r_q8 = (int16_t)((int32_t)total * 256 / (3 * 1023));
 
   if (MOTOR9_DIRS[last_motor_bin][0] == 0 && MOTOR9_DIRS[last_motor_bin][1] == 0) {
     r_q8 += MOTOR_IDLE_PENALTY_Q8;


### PR DESCRIPTION
## Summary
- Base reward on aggregate light intensity from all three LDR sensors
- Preserve idle-motor penalty and other reward/penalty behaviors

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno sketch_aug16a.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2da709d4c8329bf15ddf4f99bdf96